### PR TITLE
Fallback support for failed metadata retrieval (Fixes #13).

### DIFF
--- a/src/doi.jl
+++ b/src/doi.jl
@@ -61,11 +61,12 @@ end
 
 """
     meta-data structure from API: https://w3id.org/oc/meta/api/v1/metadata/
-""" function metadata_template(doi::String)
+"""
+function metadata_template(doi::String)
     fields = (:publisher, :pub_date, :page, :venue, :issue, :editor, :author, :id, :volume, :title, :type)
-    r1 = Dict(f=>"\u0000" for f in fields)
-    r1[:id] = doi
-    return r1
+    rj = Dict(f => "\u0000" for f in fields)
+    rj[:id] = doi
+    return rj
 end
 
 @memoize function fetch_metadata(doi::AbstractDOI)
@@ -119,7 +120,7 @@ end
 function emph_author(doi::EmDOI)
     emph_author(strip(doi.author), doi.highlight)
 end
-function emph_author(authors, author = "", em = "b")
+function emph_author(authors, author="", em="b")
     orcid = r", \d{4}-\d{4}-\d{4}-\d{4}"
     authors = replace(authors, orcid => "")
     if length(author) > 2
@@ -142,6 +143,7 @@ end
 function strip(s)
     return replace(s, r" \[(.*?)\]" => "")
 end
+
 function year(s)
-    return !isempty(s) ? parse(Int, first(s, 4)) : "\u0000"
+    return !isempty(s) && s != "\0" ? parse(Int, first(s, 4)) : nothing
 end

--- a/src/doi.jl
+++ b/src/doi.jl
@@ -59,13 +59,26 @@ function Base.show(io::IO, ::MIME"text/html", dois::Array{T} where {T<:AbstractD
     print(io, "</ol>")
 end
 
+"""
+    meta-data structure from API: https://w3id.org/oc/meta/api/v1/metadata/
+""" function metadata_template(doi::String)
+    fields = (:publisher, :pub_date, :page, :venue, :issue, :editor, :author, :id, :volume, :title, :type)
+    r1 = Dict(f=>"\u0000" for f in fields)
+    r1[:id] = doi
+    return r1
+end
+
 @memoize function fetch_metadata(doi::AbstractDOI)
     fetch_metadata(doi.doi)
 end
 @memoize function fetch_metadata(doi)
     r = HTTP.get("https://w3id.org/oc/meta/api/v1/metadata/doi:$(doi)")
     rj = JSON3.read(r.body)
-    return rj[1]
+    if isempty(rj)
+        return metadata_template(doi)
+    else
+        return rj[1]
+    end
 end
 fetch_citation_count(doi::AbstractDOI) = fetch_citation_count(doi.doi)
 @memoize function fetch_citation_count(doi)
@@ -130,5 +143,5 @@ function strip(s)
     return replace(s, r" \[(.*?)\]" => "")
 end
 function year(s)
-    return parse(Int, first(s, 4))
+    return !isempty(s) ? parse(Int, first(s, 4)) : "\u0000"
 end

--- a/src/doi.jl
+++ b/src/doi.jl
@@ -145,5 +145,5 @@ function strip(s)
 end
 
 function year(s)
-    return !isempty(s) && s != "\0" ? parse(Int, first(s, 4)) : nothing
+    return !isempty(s) && s != "\0" ? parse(Int, first(s, 4)) : s
 end

--- a/src/doi.jl
+++ b/src/doi.jl
@@ -64,7 +64,7 @@ end
 """
 function metadata_template(doi::String)
     fields = (:publisher, :pub_date, :page, :venue, :issue, :editor, :author, :id, :volume, :title, :type)
-    rj = Dict(f => "\u0000" for f in fields)
+    rj = Dict(f => "" for f in fields)
     rj[:id] = doi
     return rj
 end

--- a/src/doi.jl
+++ b/src/doi.jl
@@ -145,5 +145,5 @@ function strip(s)
 end
 
 function year(s)
-    return !isempty(s) && s != "\0" ? parse(Int, first(s, 4)) : s
+    return !isempty(s) && s != "" ? parse(Int, first(s, 4)) : s
 end


### PR DESCRIPTION
## Summary

This PR adds a new function called `metadata_template(doi)` which returns a dictionary with fields corresponding to the OpenCitations metadata structure from the new API (https://w3id.org/oc/meta/api/v1/metadata). The function populates the values with null strings except for the `id` field, which is given the DOI`::String`

Additionally, the `fetch_metadata` function has been updated with an if-else clause that checks if the returned JSON from OpenCitations is empty for a given DOI. If empty, the new `metadata_template` function is called.

No changes were made to the `Base.show` methods, but the `year` function now uses a ternary operator condition to return null string if empty. This supports `Base.getproperty` call to `year`.

This PR addresses issue #13.

## Changes

- Added `metadata_template(doi)` function
- Updated `fetch_metadata` function with if-else clause for empty JSON
- Updated `year` function with ternary operator condition for `Base.getproperty`

## Testing

No new tests were added, but existing tests pass.

## Notes

Please review the changes and let me know if you have any modifications or design pattern changes.
