### PR TITLE
youtube: use lite-youtube-embed

### DIFF
--- a/src/youtube.jl
+++ b/src/youtube.jl
@@ -18,85 +18,15 @@ YouTube(id, seektomin, seektosec) = YouTube(id, seektomin * 60 + seektosec)
 YouTube(id) = YouTube(id, 0)
 """
     Embed youtube video id that seeks seekto seconds into the video and pauses there to 
-    make it possible to show a particular still from the video by default. Note that 
-    the youtube API disallows hiding the annoying "More videos" overlay. 
+    make it possible to show a particular still from the video by default.
 """
 @memoize function youtube(id, seekto)
-    vid = string(uuid1()) # Assign each video unique id to allow multiple instances.
-    htm =
-        """
-  <div id=" """ *
-        vid *
-        """ "></div>
-<script>
-// 2. This code loads the IFrame Player API code asynchronously.
-  var tag = document.createElement('script');
+    """
+	<script src="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.js" integrity="sha256-wwYlfEzWnCf2nFlIQptfFKdUmBeH5d3G7C2352FdpWE=" crossorigin="anonymous" defer></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lite-youtube-embed@0.2.0/src/lite-yt-embed.css" integrity="sha256-99PgDZnzzjO63EyMRZfwIIA+i+OS2wDx6k+9Eo7JDKo=" crossorigin="anonymous">
 
-  tag.src = "https://www.youtube.com/iframe_api";
-  var firstScriptTag = document.getElementsByTagName('script')[0];
-  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-  // 3. This function creates an <iframe> (and YouTube player)
-  //    after the API code downloads.
-  var player;
-  function onYouTubeIframeAPIReady() {
-    player = new YT.Player(' """ *
-        vid *
-        """ ', {
-          height: '390',
-          width: '640',
-		  rel: '0',
-		  showinfo: '0',
-iv_load_policy: '3',
-showinfo: '0',
-          videoId: '""" *
-        id *
-        """',
-  //modestbranding: 1,
-        events: {
-          'onReady': onPlayerReady,
-          'onStateChange': onPlayerStateChange
-        }
-      });
-      
-    }
-
-    // 4. The API will call this function when the video player is ready.
-    function onPlayerReady(event) {
-event.target.mute();
-event.target.seekTo(""" *
-        string(seekto) *
-        """);
-        event.target.playVideo();
-      }
-
-      // 5. The API calls this function when the player's state changes.
-      //    The function indicates that when playing a video (state=1),
-      //    the player should play for six seconds and then stop.
-      var done = false;
-      function onPlayerStateChange(event) {
-        if (event.data == YT.PlayerState.PLAYING && !done) {
-          setTimeout(stopVideo, 0);
-          done = true;
-        }
-      }
-      function stopVideo() {
-        player.pauseVideo();
-      }
-      
-      // Check if YT is loaded before trying to start player
-      function pollYT () {
-        if (typeof(YT) == 'undefined') {
-            setTimeout(pollYT, 300); // try again in 300 milliseconds
-        } else {
-            onYouTubeIframeAPIReady();
-        }
-      }
-
-      pollYT();
-    </script>
-"""
-    return htm
+	<lite-youtube videoid=$(id) params="modestbranding=1&rel=0&start=$(string(seekto))"></lite-youtube>
+	"""
 end
 
 """
@@ -111,11 +41,9 @@ end
     Embed youtube video by id, uses default oembed code with reasonable size.
 """
 function youtube(id)
-    url = "https://youtube.com/oembed?url=http://www.youtube.com/watch?v=$id&format=json&maxwidth=600&maxheight=500"
-    response = HTTP.get(url)
-    json = JSON3.read(String(response.body))
-    return HTML(json[:html])
+    youtube(id, 0)
 end
+
 
 struct Flickr <: ShortCode
     id::Integer


### PR DESCRIPTION
Hey!

There is a cool JS package called [`lite-youtube-embed`](https://github.com/paulirish/lite-youtube-embed), which is a super smart way to embed youtube videos: initially, it just shows the thumbnail and the youtube logo with two `<img>` tags, and when the user clicks, it loads the embed iframe and switches over. 

This makes your page (notebook) load **much** faster (much less network and CPU usage), and it prevents google from tracking users through their youtube embed iframe. You can really notice the difference in loading times, because the default youtube iframe is quite heavy.

Their demo site: https://paulirish.github.io/lite-youtube-embed/

Another benefit is that `lite-youtube-embed` has a responsive embed: the thumbnail and iframe automatically resize to match the container width (i.e. Pluto cell), which is great for making your notebooks look nice across devices.

Notes:
- The import is from https://jsdelivr.com/, a very reliable CDN (also used in the Pluto HTML exports), and the import is version-pinned and it has a SHA integrity attribute for security.
- There is no need for the `uuid1` ID anymore because `lite-youtube-embed` already supports multiple repeated videos. We also might not need the `@memoize` anymore, up to you :)
- In this PR I replaced the old implementation with the new one, but it could also be an argument to `YouTube(...)`, or a new `YouTubeLite` struct. (But I believe that `lite-youtube-embed` is the right choice for almost users 😇)

Demo of this new functionality in Pluto:

[youtube lite embed.zip](https://github.com/hellemo/ShortCodes.jl/files/11261448/youtube.lite.embed.zip)
