### PR TITLE
Switch from HTTP.jl to Downloads.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,15 @@ version = "0.3.5"
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
-HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodecZlib = "0.7"
-HTTP = "1"
 JSON3 = "1"
 Memoize = "0.4"
+URIs = "1"
 julia = "^1.5"

--- a/src/ShortCodes.jl
+++ b/src/ShortCodes.jl
@@ -2,12 +2,19 @@ module ShortCodes
 
 using Base64
 using CodecZlib
-using HTTP
+using Downloads
+using URIs
 using JSON3
 using Memoize
 using UUIDs
 
 abstract type ShortCode end
+
+function http_get(url; kwargs...)
+	io = IOBuffer()
+	Downloads.request(url; output=io, kwargs...)
+	read(seekstart(io))
+end
 
 include("doi.jl")
 include("twitter.jl")

--- a/src/doi.jl
+++ b/src/doi.jl
@@ -63,14 +63,12 @@ end
     fetch_metadata(doi.doi)
 end
 @memoize function fetch_metadata(doi)
-    r = HTTP.get("https://w3id.org/oc/meta/api/v1/metadata/doi:$(doi)")
-    rj = JSON3.read(r.body)
+    rj = JSON3.read(http_get("https://w3id.org/oc/meta/api/v1/metadata/doi:$(doi)"))
     return rj[1]
 end
 fetch_citation_count(doi::AbstractDOI) = fetch_citation_count(doi.doi)
 @memoize function fetch_citation_count(doi)
-    r = HTTP.get("https://opencitations.net/index/api/v1/citation-count/$(doi)")
-    rj = JSON3.read(r.body)
+    rj = JSON3.read(http_get("https://opencitations.net/index/api/v1/citation-count/$(doi)"))
     return parse(Int, rj[1][:count])
 end
 
@@ -81,8 +79,7 @@ end
 end
 
 @memoize function fetch_shortdoi(doi::String)
-    r = HTTP.get("https://shortdoi.org/$(doi)?format=json")
-    return JSON3.read(r.body)
+    return JSON3.read(http_get("https://shortdoi.org/$(doi)?format=json"))
 end
 """
     expand(doi::ShortDOI)
@@ -90,8 +87,8 @@ end
 Get full DOI from doi.org
 """
 @memoize function expand(doi::ShortDOI)
-    r = HTTP.get("https://doi.org/api/handles/$(doi.shortdoi)")
-    return JSON3.read(r.body)[:values][2][:data][:value]
+    r = http_get("https://doi.org/api/handles/$(doi.shortdoi)")
+    return JSON3.read(r)[:values][2][:data][:value]
 end
 
 

--- a/src/kroki.jl
+++ b/src/kroki.jl
@@ -35,8 +35,7 @@ function kroki(krokitext, generator = "graphviz", format = "svg")
 end
 
 @memoize function fetch_kroki(krokitext, generator = "graphviz", format = "svg")
-    response = HTTP.get(kroki(krokitext, generator, format))
-    String(response.body)
+    String(http_get(kroki(krokitext, generator, format)))
 end
 
 function base64urlencode(text)

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -38,9 +38,8 @@ function Base.show(io::IO, ::MIME"text/html", video::Vimeo)
 end
 
 @memoize function vimeo(video_url)
-    url = "https://vimeo.com/api/oembed.json?url=$(HTTP.escapeuri(video_url))&maxheight=500&maxwidth=700&width=680&byline=false&portrait=false&title=false"
-    response = HTTP.get(url)
-    json = JSON3.read(String(response.body))
+    url = "https://vimeo.com/api/oembed.json?url=$(URIs.escapeuri(video_url))&maxheight=500&maxwidth=700&width=680&byline=false&portrait=false&title=false"
+    json = JSON3.read(http_get(url))
     return json[:html]
 end
 

--- a/src/twitter.jl
+++ b/src/twitter.jl
@@ -5,8 +5,7 @@ end
 
 @memoize function fetch_twitter(id)
     url = "https://publish.twitter.com/oembed?url=https://twitter.com/andypiper/status/$id"
-    response = HTTP.get(url)
-    json = JSON3.read(String(response.body))
+    json = JSON3.read(http_get(url))
 end
 
 struct Twitter <: ShortCode

--- a/src/youtube.jl
+++ b/src/youtube.jl
@@ -112,8 +112,7 @@ end
 """
 function youtube(id)
     url = "https://youtube.com/oembed?url=http://www.youtube.com/watch?v=$id&format=json&maxwidth=600&maxheight=500"
-    response = HTTP.get(url)
-    json = JSON3.read(String(response.body))
+    json = JSON3.read(http_get(url))
     return HTML(json[:html])
 end
 
@@ -136,6 +135,5 @@ end
 
 @memoize function fetch_flickr(id)
     url = "https://www.flickr.com/services/oembed/?format=json&url=http%3A//www.flickr.com/photos/bees/$id"
-    response = HTTP.get(url)
-    json = JSON3.read(String(response.body))
+    json = JSON3.read(http_get(url))
 end


### PR DESCRIPTION
Julia has a stdlib for downloading from the internet and it can be quite a bit faster! On Julia 1.8, the first `HTTP.get` call takes 10 seconds of compilation. Because Downloads is a stdlib, it is already compiled and loaded when you start Julia.

We still need URIs.jl for (un)encoding URIs, and this is a small package (normally lloaded as dependency of HTTP.jl)

The tests fail locally because of a bug in `compress` in Kroki, I think this is unrelated.