### PR TITLE
Update QR code generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ DOI("10.1137/141000671")
 
 # Show QR code for text (QRCoders extension)
 using QRCoders
-QR(raw"https://docs.julialang.org/en/v1/")
+QRCode(raw"https://docs.julialang.org/en/v1/")
 ```
 
 ## Note


### PR DESCRIPTION
It seems it was renamed from `QR` to `QRCode`, probably to avoid the clash with `LinearAlgebra.QR`.