### PR TITLE
Rename QR struct to QRC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ShortCodes"
 uuid = "f62ebe17-55c5-4640-972f-b59c0dd11ccf"
 authors = ["Lars Hellemo <hellemo@gmail.com> "]
-version = "0.3.6"
+version = "0.4.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -24,4 +24,4 @@ CodecZlib = "0.7"
 JSON3 = "1"
 Memoize = "0.4"
 URIs = "1"
-julia = "^1.5"
+julia = "^1.10"

--- a/ext/QRCodersExt/QRCodersExt.jl
+++ b/ext/QRCodersExt/QRCodersExt.jl
@@ -8,14 +8,14 @@ function _to_ascii(A, TRUE="██", FALSE="  ")
     join((join( b ? TRUE : FALSE for b in r ) for r in eachrow(A)),"\n")
 end
 
-function Base.show(io::IO, ::MIME"image/png", q::ShortCodes.QR)
+function Base.show(io::IO, ::MIME"image/png", q::ShortCodes.QRC)
     bitmap = .!qrcode(q.payload)
     N = Int(round(q.size / size(bitmap, 1)))
     bitmap = kron(bitmap, ones(Bool, N, N))
     QRCoders.FileIO.save(QRCoders.FileIO.Stream(QRCoders.FileIO.format"PNG", io), bitmap)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", q::ShortCodes.QR)
+function Base.show(io::IO, ::MIME"text/plain", q::ShortCodes.QRC)
     print(io, _to_ascii(qrcode(q.payload)))
 end
 

--- a/src/ShortCodes.jl
+++ b/src/ShortCodes.jl
@@ -35,6 +35,6 @@ export Twitter
 export Vimeo
 export WebPage
 export YouTube
-export QR
+export QRC
 
 end # module

--- a/src/extension_types.jl
+++ b/src/extension_types.jl
@@ -1,5 +1,5 @@
-struct QR{T<:AbstractString,I<:Number}
+struct QRC{T<:AbstractString,I<:Number}
     payload::T
     size::I
 end
-QR(s) = QR(s, 100)
+QRC(s) = QRC(s, 100)


### PR DESCRIPTION
Rename `QR` struct to `QRC` to avoid name clash with `LinearAlgebra` and `QRCoders`' types.